### PR TITLE
Attempt to close #1, using API that works in 0.4 and 0.6

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -142,11 +142,9 @@ SMTPClient.prototype._init = function(){
 SMTPClient.prototype.connect = function(){
 
     if(this.options.secureConnection){
-        this.socket = tls.connect(this.port, this.host);
-        this.socket.on("secureConnect", this._onConnect.bind(this));
+        this.socket = tls.connect(this.port, this.host, {}, this._onConnect.bind(this));
     }else{
-        this.socket = net.connect(this.port, this.host);
-        this.socket.on("connect", this._onConnect.bind(this));
+        this.socket = net.connect(this.port, this.host, this._onConnect.bind(this));
     }
     
     this.socket.on("error", this._onError.bind(this));


### PR DESCRIPTION
Simple change: pass the "connect" listener as a parameter, works consistently.
