### PR TITLE
Added authMethod option.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -396,6 +396,8 @@ SMTPClient.prototype._authenticateUser = function(){
     
     if(this.options.auth.XOAuthToken && this._supportedAuth.indexOf("XOAUTH")>=0){
         auth = "XOAUTH";
+    }else if(this.options.authMethod) {
+        auth = this.options.authMethod.toUpperCase().trim();
     }else{
         // use first supported
         auth = (this._supportedAuth[0] || "PLAIN").toUpperCase().trim();

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -142,6 +142,7 @@ SMTPConnectionPool.prototype._createConnection = function(){
             debug: !!this.options.debug,
             ignoreTLS: !!this.options.ignoreTLS,
             auth: this.options.auth || false,
+            authMethod: this.options.authMethod,
             name: this.options.name || false,
             secureConnection: !!this.options.secureConnection
         },


### PR DESCRIPTION
This allows users to set `authMethod` into the options for nodemailer.createTransport().

e.g.

```
var smtpTransport = nodemailer.createTransport("SMTP",{
    host: "smtp.naver.com",
    secureConnection: false,
    port: 587,
    ignoreTLS: false,
    authMethod: 'LOGIN',
    auth: {
        user: "semtlnori",
        pass: "1234",
    }
});
```

This is useful when SMTP server cannot handle some auth method even the server said it is supported.

The below is the case that I experienced. The server said `AUTH LOGIN` and `AUTH PLAIN` is both supported, however in actually it fails with `AUTH PLAIN`.

```
SERVER 1:
└──220 smtp.naver.com ESMTP for naver.com
CLIENT 1:
└──EHLO eungjun-ui-MacBook-Air.local
SERVER 1:
└──250-tsmtp03.nm.naver.com Pleased to meet you
   250-SIZE 20971520
   250-8BITMIME
   250-HELP
   250-PIPELINING
   250-AUTH LOGIN PLAIN
   250-STARTTLS
   250 ENHANCEDSTATUSCODES
CLIENT 1:
└──STARTTLS
SERVER 1:
└──220 2.7.0 Ready to start TLS.
Connection secured
CLIENT 1:
└──EHLO eungjun-ui-MacBook-Air.local
SERVER 1:
└──250-tsmtp03.nm.naver.com Pleased to meet you
   250-SIZE 20971520
   250-8BITMIME
   250-HELP
   250-PIPELINING
   250-AUTH LOGIN PLAIN
   250 ENHANCEDSTATUSCODES
CLIENT 1:
└──AUTH PLAIN c2VtdGxub3JpAHNlbXRsbm9yaQAxMjM0
SERVER 1:
└──553 5.3.0 Auth failure
{ [AuthError: Invalid login - 553 5.3.0 Auth failure] name: 'AuthError', data: '553 5.3.0 Auth failure' }
Closing connection to the server
```

I'm not sure which side makes a fault to handle `AUTH PLAIN`, the server of the client. But anyway this option helps me to send a mail successfully.

ps. I might make a mistake because I'm not good at SMTP. Sorry in advance.
