### PR TITLE
Enabled access to connection object during creation in a pool

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -10,7 +10,7 @@ module.exports = function(port, host, options){
 
 /**
  * <p>Creates a SMTP connection pool</p>
- * 
+ *
  * <p>Optional options object takes the following possible properties:</p>
  * <ul>
  *     <li><b>secureConnection</b> - use SSL</li>
@@ -20,7 +20,7 @@ module.exports = function(port, host, options){
  *     <li><b>debug</b> - output client and server messages to console</li>
  *     <li><b>maxConnections</b> - how many connections to keep in the pool</li>
  * </ul>
- * 
+ *
  * @constructor
  * @namespace SMTP Client Pool module
  * @param {Number} [port=25] The port number to connecto to
@@ -29,46 +29,46 @@ module.exports = function(port, host, options){
  */
 function SMTPConnectionPool(port, host, options){
     EventEmitter.call(this);
-    
+
     /**
      * Port number to connect to
      * @public
      */
     this.port = port || 25;
-    
+
     /**
      * Hostname to connect to
      * @public
      */
     this.host = host || "localhost";
-    
+
     /**
      * Options object
      * @public
      */
     this.options = options || {};
     this.options.maxConnections = this.options.maxConnections || 5;
-    
+
     /**
      * An array of connections that are currently idle
      * @private
      */
     this._connectionsAvailable = [];
-    
+
     /**
      * An array of connections that are currently in use
      * @private
      */
     this._connectionsInUse = [];
-    
+
     /**
      * Message queue (FIFO)
      * @private
      */
     this._messageQueue = [];
-    
+
     /**
-     * Counter for generating ID values for debugging 
+     * Counter for generating ID values for debugging
      * @private
      */
     this._idgen = 0;
@@ -78,20 +78,20 @@ utillib.inherits(SMTPConnectionPool, EventEmitter);
 /**
  * <p>Sends a message. If there's any idling connections available
  * use one to send the message immediatelly, otherwise add to queue.</p>
- * 
+ *
  * @param {Object} message MailComposer object
  * @param {Function} callback Callback function to run on finish, gets an
  *        <code>error</code> object as a parameter if the sending failed
- *        and on success an object with <code>failedRecipients</code> array as 
- *        a list of addresses that were rejected (if any) and 
+ *        and on success an object with <code>failedRecipients</code> array as
+ *        a list of addresses that were rejected (if any) and
  *        <code>message</code> which indicates the last message received from
  *        the server
  */
 SMTPConnectionPool.prototype.sendMail = function(message, callback){
     var connection;
-    
+
     message.returnCallback = callback;
-    
+
     if(this._connectionsAvailable.length){
         // if available connections pick one
         connection = this._connectionsAvailable.pop();
@@ -99,12 +99,12 @@ SMTPConnectionPool.prototype.sendMail = function(message, callback){
         this._processMessage(message, connection);
     }else{
         this._messageQueue.push(message);
-        
+
         if(this._connectionsAvailable.length + this._connectionsInUse.length < this.options.maxConnections){
             this._createConnection();
         }
     }
-    
+
 };
 
 /**
@@ -112,7 +112,7 @@ SMTPConnectionPool.prototype.sendMail = function(message, callback){
  */
 SMTPConnectionPool.prototype.close = function(callback){
     var connection;
-    
+
     // for some reason destroying the connections seem to be the only way :S
     while(this._connectionsAvailable.length){
         connection = this._connectionsAvailable.pop();
@@ -120,14 +120,14 @@ SMTPConnectionPool.prototype.close = function(callback){
             connection.socket.destroy();
         }
     }
-    
+
     while(this._connectionsInUse.length){
         connection = this._connectionsInUse.pop();
         if(connection.socket){
             connection.socket.destroy();
         }
     }
-    
+
     if(callback){
         process.nextTick(callback);
     }
@@ -147,14 +147,16 @@ SMTPConnectionPool.prototype._createConnection = function(){
             secureConnection: !!this.options.secureConnection
         },
         connection = simplesmtp.connect(this.port, this.host, connectionOptions);
-    
+
     connection.on("idle", this._onConnectionIdle.bind(this, connection));
     connection.on("message", this._onConnectionMessage.bind(this, connection));
     connection.on("ready", this._onConnectionReady.bind(this, connection));
     connection.on("error", this._onConnectionError.bind(this, connection));
     connection.on("end", this._onConnectionEnd.bind(this, connection));
     connection.on("rcptFailed", this._onConnectionRCPTFailed.bind(this, connection));
-   
+
+    this.emit('connectionCreated', connection);
+
     // as the connection is not ready yet, add to "in use" queue
     this._connectionsInUse.push(connection);
 };
@@ -162,29 +164,29 @@ SMTPConnectionPool.prototype._createConnection = function(){
 /**
  * <p>Processes a message by assigning it to a connection object and initiating
  * the sending process by setting the envelope</p>
- * 
+ *
  * @param {Object} message MailComposer message object
  * @param {Object} connection <code>simplesmtp.connect</code> connection
  */
 SMTPConnectionPool.prototype._processMessage = function(message, connection){
     connection.currentMessage = message;
     message.currentConnection = connection;
-    
+
     // send envelope
     connection.useEnvelope(message.getEnvelope());
 };
 
 /**
- * <p>Will be fired on <code>'idle'</code> events by the connection, if 
+ * <p>Will be fired on <code>'idle'</code> events by the connection, if
  * there's a message currently in queue</p>
- * 
+ *
  * @event
  * @param {Object} connection Connection object that fired the event
  */
 SMTPConnectionPool.prototype._onConnectionIdle = function(connection){
-    
+
     var message = this._messageQueue.shift();
-    
+
     if(message){
         this._processMessage(message, connection);
     }else{
@@ -196,12 +198,11 @@ SMTPConnectionPool.prototype._onConnectionIdle = function(connection){
         }
         this._connectionsAvailable.push(connection);
     }
-    
 };
 
 /**
  * <p>Will be called when not all recipients were accepted</p>
- * 
+ *
  * @event
  * @param {Object} connection Connection object that fired the event
  * @param {Array} addresses Failed addresses as an array of strings
@@ -214,7 +215,7 @@ SMTPConnectionPool.prototype._onConnectionRCPTFailed = function(connection, addr
 
 /**
  * <p>Will be called when the client is waiting for a message to deliver</p>
- * 
+ *
  * @event
  * @param {Object} connection Connection object that fired the event
  */
@@ -227,7 +228,7 @@ SMTPConnectionPool.prototype._onConnectionMessage = function(connection){
 
 /**
  * <p>Will be called when a message has been delivered</p>
- * 
+ *
  * @event
  * @param {Object} connection Connection object that fired the event
  * @param {Boolean} success True if the message was queued by the SMTP server
@@ -244,13 +245,13 @@ SMTPConnectionPool.prototype._onConnectionReady = function(connection, success, 
             if(message){
                 responseObj.message = message;
             }
-             
+
             connection.currentMessage.returnCallback(null, responseObj);
-            
+
         }else{
             error = new Error("Message delivery failed");
             error.name = "DeliveryError";
-            connection.currentMessage.returnCallback(error); 
+            connection.currentMessage.returnCallback(error);
         }
     }
     connection.currentMessage = false;
@@ -258,7 +259,7 @@ SMTPConnectionPool.prototype._onConnectionReady = function(connection, success, 
 
 /**
  * <p>Will be called when an error occurs</p>
- * 
+ *
  * @event
  * @param {Object} connection Connection object that fired the event
  * @param {Object} error Error object
@@ -266,12 +267,12 @@ SMTPConnectionPool.prototype._onConnectionReady = function(connection, success, 
 SMTPConnectionPool.prototype._onConnectionError = function(connection, error){
     var message = connection.currentMessage;
     connection.currentMessage = false;
-    
+
     // clear a first message from the list, otherwise an infinite loop will emerge
     if(!message){
         message = this._messageQueue.shift();
     }
-    
+
     if(message && message.returnCallback){
         message.returnCallback(error);
     }
@@ -279,13 +280,13 @@ SMTPConnectionPool.prototype._onConnectionError = function(connection, error){
 
 /**
  * <p>Will be called when a connection to the client is closed</p>
- * 
+ *
  * @event
  * @param {Object} connection Connection object that fired the event
  */
 SMTPConnectionPool.prototype._onConnectionEnd = function(connection){
     var removed = false, i, len;
-    
+
     // if in "available" list, remove
     for(i=0, len = this._connectionsAvailable.length; i<len; i++){
         if(this._connectionsAvailable[i] == connection){
@@ -294,7 +295,7 @@ SMTPConnectionPool.prototype._onConnectionEnd = function(connection){
             break;
         }
     }
-    
+
     if(!removed){
         // if in "in use" list, remove
         for(i=0, len = this._connectionsInUse.length; i<len; i++){
@@ -305,10 +306,10 @@ SMTPConnectionPool.prototype._onConnectionEnd = function(connection){
             }
         }
     }
-    
+
     // if there's still unprocessed mail and available connection slots, create
     // a new connection
-    if(this._messageQueue.length && 
+    if(this._messageQueue.length &&
       this._connectionsInUse.length + this._connectionsAvailable.length < this.options.maxConnections){
         this._createConnection();
     }


### PR DESCRIPTION
Like I noted in the code, I changed the _createConnection (line 158) function of pool.js to emit an event called 'connectionCreated' to the current connectionPool object.  This will enable me critical insight to why a connection fails, etc.  Now I realize that this may open the door for a someone to do something to the connection that may screw with the control the pool offers.  So I don't know if opening up the entire connection is correct, maybe just exposing the start, error, and end events make sense.  Any thoughts?

Example:

```
pool.on('connectionCreated', function(connection) {

    connection.on('error', function(err) {
        console.log('connection errored: ', err);
    });

    connection.on('end', function() {
        console.log('connection end');
    });

});
```
