### PR TITLE
MAIL FROM options

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -319,7 +319,7 @@ SMTPServerConnection.prototype._onCommandMAIL = function(mail){
         return this.client.send("503 5.5.1 Error: nested MAIL command");
     }
     
-    if(!(match = mail.match(/^from\:\s*<([^@>]+\@([^@>]+))>$/i))){
+    if(!(match = mail.match(/^from\:\s*<([^@>]+\@([^@>]+))>(\s|$)/i))){
         return this.client.send("501 5.1.7 Bad sender address syntax");
     }
     

--- a/test/server.js
+++ b/test/server.js
@@ -144,6 +144,13 @@ exports["General tests"] = {
             test.done();
         });
     },
+    "MAIL FROM options": function(test){
+        var cmds = ["HELO FOO", "MAIL FROM:<test@gmail.com> BODY=8BITMIME"];
+        runClientMockup(PORT_NUMBER, "localhost", cmds, function(resp){
+            test.ok(resp.toString("utf-8").match(/^250/));
+            test.done();
+        });
+    },
     "MAXSIZE": function(test){
         var cmds = ["EHLO FOO"];
         runClientMockup(PORT_NUMBER, "localhost", cmds, function(resp){


### PR DESCRIPTION
Simplesmtp server now rejects MAIL FROM command if there's anything else except an email address. But according to [RFC1652](http://www.ietf.org/rfc/rfc1652.txt), passing options there is quite legal, and Postfix really use it.

```
220 dev ESMTP node.js simplesmtp
EHLO dev.example.com
250-dev at your service, [127.0.0.1]
250-8BITMIME
250-ENHANCEDSTATUSCODES
250 STARTTLS
MAIL FROM:<test@gmail.com> BODY=8BITMIME
501 5.1.7 Bad sender address syntax
RSET
250 2.0.0 Ok
QUIT
221 2.0.0 Goodbye!
```
