### PR TITLE
DNS lookup happens when options.disableDNSValidation is true

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -7,8 +7,7 @@ var RAIServer = require("rai").RAIServer,
     EventEmitter = require('events').EventEmitter,
     oslib = require('os'),
     utillib = require("util"),
-    dnslib = require("dns"),
-    async = require("async");
+    dnslib = require("dns");
 
 // expose to the world
 module.exports = function(options){
@@ -330,45 +329,13 @@ SMTPServerConnection.prototype._onCommandMAIL = function(mail){
     email = match[1] || "";
     domain = (match[2] || "").toLowerCase();
     
-    async.series([
-        function (next) {
-            if(!self.server.options.disableDNSValidation) {
-              dnslib.resolveMx(domain, function(err, addresses){
-                  if(err || !addresses || !addresses.length){
-                      self.server.emit("senderValidationFailed", email);
-                      next(new Error("450 4.1.8 <"+email+">: Sender address rejected: Domain not found"))
-                      return;
-                  }
-                  next();
-              })
-            } else {
-                next();
-            };
-        },
-        function (next) {
-            if(self.server.options.validateSender){
-                self.server.emit("validateSender", self.envelope, email, function(err){
-                    if(err){
-                        next(new Error("550 5.1.1 <"+email+">: Sender address rejected: User unknown in local sender table"));
-                        return;
-                    }
-                    next();
-                });
-            } else {
-                next();
-            }
-        },
-        function (next) {
-            email = email.substr(0, email.length - domain.length) + domain;
-            self.envelope.from = email;
-            self.client.send("250 2.1.0 Ok");
-            next();
+    this._validateAddress("sender", email, domain, function (err) {
+        if (err) {
+            return self.client.send(err.message);
         }
-    ],
-    function (err) {
-      if (err) {
-        self.client.send(err.message);
-      }
+        email = email.substr(0, email.length - domain.length) + domain;
+        self.envelope.from = email;
+        self.client.send("250 2.1.0 Ok");
     });
 };
 
@@ -400,52 +367,93 @@ SMTPServerConnection.prototype._onCommandRCPT = function(mail){
     email = match[1] || "";
     domain = (match[2] || "").toLowerCase();
     
-    async.series([
-        function (next) {
-            if(!self.server.options.disableDNSValidation) {
-                dnslib.resolveMx(domain, function(err, addresses){
-                    if(err || !addresses || !addresses.length){
-                        self.server.emit("recipientValidationFailed", email);
-                        next(new Error("450 4.1.8 <"+email+">: Recipient address rejected: Domain not found"));
-                        return;
-                    }
-                    next();
-                });
-            } else {
-                next();
-            }
-        },
-        function (next) {
-            if(self.server.options.validateRecipients){
-                self.server.emit("validateRecipient", self.envelope, email, function(err){
-                    if(err){
-                        next(new Error("550 5.1.1 <"+email+">: Recipient address rejected: User unknown in local recipient table"));
-                        return;
-                    }
-                    next();
-                });
-            } else {
-              next();
-            }
-        },
-        function (next) {
-            // force domain part to be lowercase
-            email = email.substr(0, email.length - domain.length) + domain;
-            
-            // add to recipients list
-            if(self.envelope.to.indexOf(email)<0){
-                self.envelope.to.push(email);
-            }
-            self.client.send("250 2.1.0 Ok");
-            next();
-        },
-    ],
-    function (err) {
-      if (err) {
-        self.client.send(err.message);
-      }
+    this._validateAddress("recipient", email, domain, function (err) {
+        if (err) {
+            return self.client.send(err.message);
+        }
+      
+        // force domain part to be lowercase
+        email = email.substr(0, email.length - domain.length) + domain;
+      
+        // add to recipients list
+        if(self.envelope.to.indexOf(email)<0){
+            self.envelope.to.push(email);
+        }
+        self.client.send("250 2.1.0 Ok");
     });
+
 };
+
+/**
+ * <p>If <code>disableDNSValidation</code> option is set to false, then performs
+ * validation via DNS lookup.
+ *
+ * <p>If <code>validate{type}</code> option is set to true, then emits
+ * <code>'validate{type}'</code> and waits for the callback before moving
+ * on</p>
+ * 
+ * @param {String} addressType 'sender' or 'recipient'
+ * @param {String} email
+ * @param {String} domain
+ * @param {Function} callback
+ */
+SMTPServerConnection.prototype._validateAddress = function (addressType, email, domain, callback) {
+
+    var self = this,
+        validateType,
+        validateEvent,
+        validationFailedEvent,
+        dnsErrorMessage,
+        localErrorMessage;
+
+    if (addressType === "sender") {
+        validateType = self.server.options.validateSender;
+        validateEvent = "validateSender";
+        validationFailedEvent = "senderValidationFailed";
+        dnsErrorMessage = "450 4.1.8 <"+email+">: Sender address rejected: Domain not found";
+        localErrorMessage = "550 5.1.1 <"+email+">: Sender address rejected: User unknown in local sender table";
+    } else if (addressType === "recipient") {
+        validateType = self.server.options.validateRecipients;
+        validateEvent = "validateRecipient";
+        validationFailedEvent = "recipientValidationFailed";
+        dnsErrorMessage = "450 4.1.8 <"+email+">: Recipient address rejected: Domain not found"
+        localErrorMessage = "550 5.1.1 <"+email+">: Recipient address rejected: User unknown in local recipient table";
+    } else {
+      // How are internal errors handled?
+      throw new Error('Address type not supported');
+      return;
+    }
+
+    var validateViaDNS = function () {
+        if(!self.server.options.disableDNSValidation) {
+            dnslib.resolveMx(domain, function(err, addresses){
+                if(err || !addresses || !addresses.length){
+                    self.server.emit(validationFailedEvent, email);
+                    return callback(new Error(dnsErrorMessage));
+                }
+                return validateViaLocal();
+            });
+        } else {
+            return validateViaLocal();
+        }
+    };
+
+    var validateViaLocal = function () {
+        if(validateType){
+            self.server.emit(validateEvent, self.envelope, email, function(err){
+                if(err){
+                    return callback(new Error(localErrorMessage));
+                }
+                return callback();
+            });
+        } else {
+            return callback();
+        }
+    };
+
+    validateViaDNS();
+
+}
 
 /**
  * <p>Switch to data mode and starts waiting for a binary data stream. Emits

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     ],
     "dependencies": {
         "rai": "*",
-        "xoauth2": "*",
-        "async": "*"
+        "xoauth2": "*"
     },
     "devDependencies": {
         "nodeunit": "*",


### PR DESCRIPTION
I have updated server.js `SMTPServerConnection.prototype._onCommandMAIL` and `SMTPServerConnection.prototype._onCommandRCPT` to not use dns lookup if options.disableDNSValidation is true.

I also refactored each method to use the async library, which removed repeating code, and added the async dependency to package.json.
