### PR TITLE
Added support for the client to authenticate using CRAM-MD5

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -534,6 +534,11 @@ SMTPClient.prototype._actionEHLO = function(str){
         this._supportedAuth.push("LOGIN");
     }
     
+    // Detect if the server supports CRAM-MD5 auth
+    if(str.match(/AUTH(?:\s+[^\n]*\s+|\s+)CRAM-MD5/i)){
+        this._supportedAuth.push("CRAM-MD5");
+    }
+
     // Detect if the server supports XOAUTH auth
     if(str.match(/AUTH(?:\s+[^\n]*\s+|\s+)XOAUTH/i)){
         this._supportedAuth.push("XOAUTH");


### PR DESCRIPTION
Depends on the [crypto](http://nodejs.org/api/crypto.html) module.

Added two functions, one which [performs the hashing and sends a response to the server's challenge string](http://en.wikipedia.org/wiki/CRAM-MD5#Protocol), and one function that checks the server's reply to determine whether we logged in successfully.

Altered the `_actionEHLO` function to check for CRAM-MD5 as a supported auth type.
