### PR TITLE
Fix error due to: 503 bad command sequence

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -818,8 +818,14 @@ SMTPClient.prototype._actionDATA = function(str){
     // response should be 354 but according to this issue https://github.com/eleith/emailjs/issues/24
     // some servers might use 250 instead, so lets check for 2 or 3 as the first digit
     if([2,3].indexOf(Number(str.charAt(0)))<0){
-        this._onError(new Error("Data command failed - " + str), false, str);
-        return;
+		
+		if( str.charAt(0)!='5' )
+		{
+			this._onError(new Error("Data command failed - " + str), false, str);
+			return;
+		}
+		
+		this.close();
     }
     
     // Emit that connection is set up for streaming


### PR DESCRIPTION
503 bad command sequence was creating an unhandled error. 
This fixed it for me but I don't pretend to think this is the right solution.

SERVER 1:
└──503 Bad command sequence

events.js:66
        throw arguments[1]; // Unhandled 'error' event
                       ^
Error: Data command failed - 503 Bad command sequence
    at SMTPClient._actionDATA (/home/jpx/mailapp/node_modules/nodemailer/node_modules/simplesmtp/lib/client.js:806:23)
    at SMTPClient._onData (/home/jpx/mailapp/node_modules/nodemailer/node_modules/simplesmtp/lib/client.js:252:29)
    at Socket.EventEmitter.emit (events.js:88:17)
    at TCP.onread (net.js:395:14)
