### PR TITLE
Fix crash by ignoring data after SMTPClient has been destroyed 

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -220,6 +220,7 @@ SMTPClient.prototype._onConnect = function(){
 SMTPClient.prototype._destroy = function(){
     if(this._destroyed)return;
     this._destroyed = true;
+    this._ignoreData = true;
     this.emit("end");
     this.removeAllListeners();
 };


### PR DESCRIPTION
This pull request fixes a crash I encountered.

When sending an e-mail to a recipient with a weird e-mail address (say, containing a % or a !), my mail server (Exim4) will reject it.

This makes simplesmtp in lib/client.js:783 raise an error:

```
    this._onError(new Error("Can't send mail - no recipients defined"), "RecipientError");
```

The _onError handler closes the connection by calling this.close() which in turn calls _destroy.

The culprit is, with my local mail server (it doesn't happen with a remote server on another machine), _onData is called once more _after_ _destroy has been called. This leads to a unhandled error event (and application crash) since the 'error' listener was cleared by _destroy already:

```
events.js:68
        throw arguments[1]; // Unhandled 'error' event
                       ^
RecipientError: Can't send mail - all recipients were rejected
    at SMTPClient._actionRCPT ([...]/node_modules/nodemailer/node_modules/simplesmtp/lib/client.js:808:27)
    at SMTPClient._onData ([...]/node_modules/nodemailer/node_modules/simplesmtp/lib/client.js:261:29)
    at Socket.EventEmitter.emit (events.js:93:17)
    at TCP.onread (net.js:396:14)
```

Setting _ignoreData to true in _destroy avoids processing any data after listeners have been cleared.
