### PR TITLE
Add server response message to delivery errors

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -267,6 +267,7 @@ SMTPConnectionPool.prototype._onConnectionReady = function(connection, success, 
         }else{
             error = new Error("Message delivery failed" + (message?": "+message:""));
             error.name = "DeliveryError";
+            error.message = message;
             connection.currentMessage.returnCallback(error);
         }
     }


### PR DESCRIPTION
In many cases an smtp server will reject the mail and provide a response explaining why. This adds that response to the DeliveryError Error object.
