### PR TITLE
Fixed error handler on upgraded connections

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -171,6 +171,7 @@ SMTPClient.prototype.connect = function(){
 SMTPClient.prototype._upgradeConnection = function(callback){
     this._ignoreData = true;
     this.socket.removeAllListeners("data");
+    this.socket.removeAllListeners("error");
 
     var opts = {
         socket: this.socket,
@@ -189,6 +190,7 @@ SMTPClient.prototype._upgradeConnection = function(callback){
 
         return callback(null, true);
     }).bind(this));
+    this.socket.on("error", this._onError.bind(this));
 };
 
 /**


### PR DESCRIPTION
Hello!

Short version: The error handler on upgraded connections was firing, but still raising an uncaught exception as well. This patch fixes it by removing the old handler and installing a new one on connection upgrade.

Long version: I was using Nodemailer with Mailgun, and getting uncaught ECONNRESET exceptions in Node 5 minutes after sending mail. I contacted Mailgun support and confirmed that indeed, they kill open SMTP connections after 5 minutes of inactivity by design. I was digging deeper into simplesmtp, thinking I'd make the connection timeout configurable to work around the issue, but then dug to the bottom of why the exception wasn't getting handled by the error handler, and eventually figured out it was due to the upgraded connection, and than removing and re-adding the handler solved it.

Thanks for Nodemailer/simplesmtp :)

-Ken
