### PR TITLE
allow to specify local address where client has bind to also for secure connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ The following connection options can be used with `simplesmtp.connect`:
   * **tls** - optional options object for `tls.connect`, also applies to STARTTLS. For example `rejectUnauthorized` is set to `false` by default. You can override this option by setting `tls: {rejectUnauthorized: true}`
   * **debug** - output client and server messages to console
   * **instanceId** - unique instance id for debugging (will be output console with the messages)
+  * **localAddress** - local interface to bind to for network connections (needs Node.js >= 0.11.3 for working with tls)
 
 ### Connection events
 
@@ -313,6 +314,7 @@ The following connection options can be used with `simplesmtp.connect`:
   * **ignoreTLS** - ignore server support for STARTTLS
   * **debug** - output client and server messages to console
   * **maxConnections** - how many connections to keep in the pool (defaults to 5)
+  * **localAddress** - local interface to bind to for network connections (needs Node.js >= 0.11.3 for working with tls)
 
 ### Send an e-mail
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -28,6 +28,7 @@ module.exports = function(port, host, options){
  *     <li><b>tls</b> - options for createCredentials</li>
  *     <li><b>debug</b> - output client and server messages to console</li>
  *     <li><b>instanceId</b> - unique instance id for debugging</li>
+ *     <li><b>localAddress</b> - outbound address to bind to (see: http://nodejs.org/api/net.html#net_net_connect_options_connectionlistener)</li>
  * </ul>
  *
  * @constructor
@@ -153,9 +154,20 @@ SMTPClient.prototype._init = function(){
  */
 SMTPClient.prototype.connect = function(){
     if(this.options.secureConnection){
-        this.socket = tls.connect(this.port, this.host, this.options.tls || {rejectUnauthorized: false}, this._onConnect.bind(this));
+        var opts = {};
+        if (this.options.tls) {
+            Object.keys(this.options.tls).forEach((function(key) {
+                opts[key] = this.options.tls[key];
+            }).bind(this));
+        }
+        else {
+            opts.rejectUnauthorized = false;
+        }
+        opts.localAddress = this.options.localAddress;
+
+        this.socket = tls.connect(this.port, this.host, opts, this._onConnect.bind(this));
     }else{
-        this.socket = net.connect(this.port, this.host);
+        this.socket = net.connect({port: this.port, host: this.host, localAddress: this.options.localAddress});
         this.socket.on("connect", this._onConnect.bind(this));
     }
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -150,6 +150,7 @@ SMTPConnectionPool.prototype._createConnection = function(){
     var connectionOptions = {
             instanceId: ++this._idgen,
             debug: !!this.options.debug,
+            localAddress: this.options.localAddress,
             ignoreTLS: !!this.options.ignoreTLS,
             tls: this.options.tls || false,
             auth: this.options.auth || false,


### PR DESCRIPTION
net module understand 'localAddress' option, where is address where it bind to. tls module understand it since last unstable, 0.11.3. This patch give us possibility to use this options.
