### PR TITLE
minor adjustments for better portability with browserify

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -175,8 +175,7 @@ SMTPClient.prototype.connect = function(){
 
         this.socket = tls.connect(this.port, this.host, opts, this._onConnect.bind(this));
     }else{
-        this.socket = net.connect({port: this.port, host: this.host, localAddress: this.options.localAddress});
-        this.socket.on("connect", this._onConnect.bind(this));
+        this.socket = net.connect({port: this.port, host: this.host, localAddress: this.options.localAddress}, this._onConnect.bind(this));
     }
 
     this.socket.on("error", this._onError.bind(this));
@@ -274,7 +273,7 @@ SMTPClient.prototype._onData = function(chunk){
     }
 
     // Wait until end of line
-    if(chunk[chunk.length-1] != 0x0A){
+    if(chunk.readUInt8(chunk.length-1) != 0x0A){
         this._remainder += chunk.toString();
         return;
     }else{


### PR DESCRIPTION
Hi Andris,

first of all thanks for your awesome email libs. We were able to port simplesmtp to a chrome packaged app using chrome.socket.

We only had to adjust the syntax in two lines of code to ease porting via browserify. This patch does not change anything semantically. Perhaps this would ease porting of your lib to other browsers as well.

Thanks
