### PR TITLE
Client parser hangs on certain input

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -283,7 +283,7 @@ SMTPClient.prototype._onData = function(chunk){
 
     // if this is a multi line reply, wait until the ending
     if(str.match(/(?:^|\n)\d{3}-.+$/)){
-        this._remainder = str;
+        this._remainder = str + "\r\n";
         return;
     }
 


### PR DESCRIPTION
When parsing the EHLO response if the data arrives in specific chunks the client will "hang" and never emit 'idle'.

Here's an example that produces the bug: https://gist.github.com/dannycoates/6286979

It should print 'ok' and exit, but it does not.
