### PR TITLE
Fixed bugs in connection timeout implementation

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -498,11 +498,18 @@ SMTPClient.prototype.close = function(){
     if(this.options.logFile){
         this.log("Closing connection to the server");
     }
-    if(this.socket && this.socket.socket && this.socket.socket.end && !this.socket.socket.destroyed){
-        this.socket.socket.end();
+    var closeMethod = "end";
+    if (this.stage === "init") {
+        // Clear connection timeout timer if other than timeout error occurred
+        clearTimeout(this._connectionTimeout);
+        // Close the socket immediately when connection timed out
+        closeMethod = "destroy";
     }
-    if(this.socket && this.socket.end && !this.socket.destroyed){
-        this.socket.end();
+    if(this.socket && this.socket.socket && this.socket.socket[closeMethod] && !this.socket.socket.destroyed){
+        this.socket.socket[closeMethod]();
+    }
+    if(this.socket && this.socket[closeMethod] && !this.socket.destroyed){
+        this.socket[closeMethod]();
     }
     this._destroy();
 };


### PR DESCRIPTION
Bugs:
1. In `init` stage, if an error occurred before the connection timeout error, the timer was not cleared.
2. When connection timed out, the socket was not closed immediately, still had to wait for an extra time.
