### PR TITLE
Inserts an extra dot at the begining of a line if it starts with a dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The following connection options can be used with `simplesmtp.connect`:
   * **connectionTimeout** (system default if not set) - Time to wait in ms until the socket is opened to the server
   * **rejectUnathorized** (defaults to false) - if set to true accepts only valid server certificates. You can override this option with the `tls` option, this is just a shorthand
   * **dsn** - An object with methods `success`, `failure` and `delay`. If any of these are set to true, DSN will be used
+  * **disableDotEscaping** set to true if you want to bypass the dot escaping at the begining of each line. Default to false
 
 ### Connection events
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -59,6 +59,8 @@ function SMTPClient(port, host, options){
     this.options.secureConnection = !!this.options.secureConnection;
     this.options.auth = this.options.auth || false;
     this.options.maxConnections = this.options.maxConnections || 5;
+    this.options.disableDotEscaping = this.options.disableDotEscaping || false;
+
 
     if(!this.options.name){
         // defaul hostname is machine hostname or [IP]
@@ -423,8 +425,18 @@ SMTPClient.prototype.write = function(chunk){
     if(typeof chunk == "string"){
         chunk = new Buffer(chunk, "utf-8");
     }
-	
-	chunk = this._escapeDot(chunk);
+
+    if (this.options.disableDotEscaping) {
+        if (chunk.length>=2) {
+            this._lastDataBytes[0] = chunk[chunk.length-2];
+            this._lastDataBytes[1] = chunk[chunk.length-1];
+        } else if (chunk.length==1) {
+            this._lastDataBytes[0] = this._lastDataBytes[1]
+            this._lastDataBytes[1] = chunk[0];
+        }
+    } else {
+        chunk = this._escapeDot(chunk);
+    }
 
     if(this.options.debug){
         console.log("CLIENT (DATA)"+(this.options.instanceId?" "+


### PR DESCRIPTION
This patch will add an extra dot at the begining of the lines that starts with a dot when they are sended with the client. If you don't do that, the SMTP servers will remove this dots.

I detected this problem because DKIM signed messages will not pass the checks.

See RFC 2821 Section 4.5.2
