### PR TITLE
Ignore OAuth2 errors from destroyed connections

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -600,6 +600,10 @@ SMTPClient.prototype._authenticateUser = function(){
         case "XOAUTH2":
             this._currentAction = this._actionAUTHComplete;
             this._xoauth2.getToken((function(err, token){
+                if(this._destroyed){
+                    // Nothing to do here anymore, connection already closed
+                    return;
+                }
                 if(err){
                     this._onError(err, "XOAUTH2Error");
                     return;


### PR DESCRIPTION
Previous fix (#70) only fixed OAuth 1; sorry.
Fully fixes #68

Question: Should this check be moved to `_onError()`, so that all protocol errors from destroyed connections are silently swallowed? (https://github.com/andris9/simplesmtp/blob/master/lib/client.js#L355)
