### PR TITLE
Allowed persistence of custom properties when resetting envelope state.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -158,7 +158,13 @@ function SMTPServerConnection(server, client){
  * @param {Boolean} [keepAuthData=false] If set to true keep authentication data
  */
 SMTPServerConnection.prototype.init = function(keepAuthData){
-    this.envelope = {from: "", to:[], date: new Date()};
+    if (this.envelope === undefined) {
+        this.envelope = {};
+    }
+    
+    this.envelope.from = "";
+    this.envelope.to = [];
+    this.envelope.date = new Date();
 
     if(this.hostNameAppearsAs){
         this.envelope.host = this.hostNameAppearsAs;


### PR DESCRIPTION
When resetting the envelope state, any custom properties that may have been populated on the envelope are removed. This pull request resets only the necessary properties on the envelope - leaving any custom properties to be handled by the user's own libraries.

I haven't yet written a test for this, but I have verified it's workings in my own code. If you'd like a test set up for accepting, I'm more than happy to do so.
