### PR TITLE
Client bug fixing and improve

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -706,27 +706,27 @@ SMTPClient.prototype._actionEHLO = function(str){
     }
 
     // Detect if the server supports PLAIN auth
-    if(str.match(/AUTH(?:\s+[^\n]*\s+|\s+)PLAIN/i)){
+    if(str.match(/AUTH(?:(\s+|=)[^\n]*\s+|\s+|=)PLAIN/i)){
         this._supportedAuth.push("PLAIN");
     }
 
     // Detect if the server supports LOGIN auth
-    if(str.match(/AUTH(?:\s+[^\n]*\s+|\s+)LOGIN/i)){
+    if(str.match(/AUTH(?:(\s+|=)[^\n]*\s+|\s+|=)LOGIN/i)){
         this._supportedAuth.push("LOGIN");
     }
 
     // Detect if the server supports CRAM-MD5 auth
-    if(str.match(/AUTH(?:\s+[^\n]*\s+|\s+)CRAM-MD5/i)){
+    if(str.match(/AUTH(?:(\s+|=)[^\n]*\s+|\s+|=)CRAM-MD5/i)){
         this._supportedAuth.push("CRAM-MD5");
     }
 
     // Detect if the server supports XOAUTH auth
-    if(str.match(/AUTH(?:\s+[^\n]*\s+|\s+)XOAUTH/i)){
+    if(str.match(/AUTH(?:(\s+|=)[^\n]*\s+|\s+|=)XOAUTH/i)){
         this._supportedAuth.push("XOAUTH");
     }
 
     // Detect if the server supports XOAUTH2 auth
-    if(str.match(/AUTH(?:\s+[^\n]*\s+|\s+)XOAUTH2/i)){
+    if(str.match(/AUTH(?:(\s+|=)[^\n]*\s+|\s+|=)XOAUTH2/i)){
         this._supportedAuth.push("XOAUTH2");
     }
 


### PR DESCRIPTION
- Fixed a Buffer building bug:
  to make sure the value passing into Buffer constructor is a real string rather than an integer and avoid making a `new Buffer(int)` by accident from user's wrong input type
- Improved auth supports detection: 
  detect for broken servers those may only return `AUTH=PLAIN LOGIN ...` and not include `AUTH PLAIN LOGIN ...`
