### PR TITLE
Allow null return sender in mail command

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -348,7 +348,7 @@ SMTPServerConnection.prototype._onCommandMAIL = function(mail){
         return this.client.send("503 5.5.1 Error: nested MAIL command");
     }
 
-    if(!(match = mail.match(/^from\:\s*<([^@>]+\@([^@>]+))>(\s|$)/i))){
+    if(!(match = mail.match(/^from\:\s*<([^@>]+\@([^@>]+))>(\s|$)/i)) && !(mail.match(/^from\:\s*<>/i))){
         return this.client.send("501 5.1.7 Bad sender address syntax");
     }
 
@@ -358,8 +358,8 @@ SMTPServerConnection.prototype._onCommandMAIL = function(mail){
         });
     }
 
-    email = match[1] || "";
-    domain = (match[2] || "").toLowerCase();
+    email = (match!==null && match[1]) || "";
+    domain = ((match!==null && match[2]) || "").toLowerCase();
 
     this._validateAddress("sender", email, domain, function (err) {
         if (err) {


### PR DESCRIPTION
We have had issues with a remote mail server bouncing messages we are trying to send to because the remote server is trying to verify our server. 

550-Callback setup failed while verifying xxx@xxx.xxx
550-(result of an earlier callout reused). 
550-The initial connection, or a HELO or MAIL FROM:<> command was 
550-rejected. Refusing MAIL FROM:<> does not help fight spam, disregards 
550-RFC requirements, and stops you from receiving standard bounce 
550-messages. This host does not accept mail from domains whose servers 
550-refuse bounces.

Checked RFC 2821 in 3.7 specifies that a null sender in the MAIL FROM command is valid.

Thanks
